### PR TITLE
Collision detect

### DIFF
--- a/car.js
+++ b/car.js
@@ -12,6 +12,7 @@ class Car {
         this.friction=0.05;
         this.angle=0; //car can exceed maxSpeed at left, right movements, need this to save physics
         this.controls = new Controls()
+
     }
 
     #move(){
@@ -62,24 +63,50 @@ class Car {
     }
 
     draw(ctx) {
-        ctx.save();
-        ctx.translate(this.x, this.y); //translate based on where we want ctx centered at
-        ctx.rotate(-this.angle);
-        ctx.beginPath();
-        ctx.rect(
-            -this.width/2, //x is gonna be center
-            -this.height/2,
-            this.width,
-            this.height
-        )
-        ctx.fill();
-        ctx.restore(); //must restore otherwise translate and rotate infinitely
-
+        ctx.beginPath()
+        ctx.moveTo(this.polygon[0].x, this.polygon[0].y)
+        for(let i =1; i<this.polygon.length;i++){
+                ctx.lineTo(this.polygon[i].x, this.polygon[i].y)
+        }
+        ctx.fill()
         this.sensor.draw(ctx)
     }
 
+    #createPolygon(){
+        //find radius and angle of beam extending from center of car
+        const points = []
+        const rad = Math.hypot(this.width, this.height)/2
+        const alpha = Math.atan2(this.width, this.height)
+        points.push(
+            {
+                x: this.x-Math.sin(this.angle-alpha)*rad,
+                y:this.y-Math.cos(this.angle-alpha)*rad
+            }
+        )
+        points.push(
+            {
+                x: this.x-Math.sin(this.angle+alpha)*rad,
+                y:this.y-Math.cos(this.angle+alpha)*rad
+            }
+        )
+        points.push(
+            {
+                x: this.x-Math.sin(Math.PI+this.angle-alpha)*rad,
+                y:this.y-Math.cos(Math.PI+this.angle-alpha)*rad
+            }
+        )
+        points.push(
+            {
+                x: this.x-Math.sin(Math.PI+this.angle+alpha)*rad,
+                y:this.y-Math.cos(Math.PI+this.angle+alpha)*rad
+            }
+        )
+        return points;
+    }
+
     update(roadBorders){
-        this.#move()
-        this.sensor.update(roadBorders)
+        this.#move();
+        this.polygon=this.#createPolygon();
+        this.sensor.update(roadBorders);
     }
 }

--- a/car.js
+++ b/car.js
@@ -11,6 +11,7 @@ class Car {
         this.maxSpeed =3;
         this.friction=0.05;
         this.angle=0; //car can exceed maxSpeed at left, right movements, need this to save physics
+        this.damaged=false;
         this.controls = new Controls()
 
     }
@@ -63,6 +64,7 @@ class Car {
     }
 
     draw(ctx) {
+        ctx.fillStyle = this.damaged ? "gray" : "black";
         ctx.beginPath()
         ctx.moveTo(this.polygon[0].x, this.polygon[0].y)
         for(let i =1; i<this.polygon.length;i++){
@@ -104,9 +106,24 @@ class Car {
         return points;
     }
 
+    #assessDamage(roadBorders){
+        //loop through borders
+        
+        for (let i = 0; i <roadBorders.length; i++){
+            if (polyIntersect(this.polygon, roadBorders[i])){
+                return true;
+            }
+        }
+        return false;
+    }
+
     update(roadBorders){
-        this.#move();
-        this.polygon=this.#createPolygon();
+        if (!this.damaged){
+            this.#move();
+            this.polygon=this.#createPolygon();
+            this.damaged=this.#assessDamage(roadBorders)
+        }
+    
         this.sensor.update(roadBorders);
     }
 }

--- a/utils.js
+++ b/utils.js
@@ -21,3 +21,21 @@ function getIntersection(A,B,C,D){
 
     return null
 }
+
+function polyIntersect(poly1, poly2){
+    for (let i = 0; i<poly1.length; i++){
+        for (let j = 0; j < poly2.length; j++){
+            const touch = getIntersection(
+                poly1[i],
+                poly1[(i+1)%poly1.length],
+                poly2[j],
+                poly2[(j+1)%poly2.length]
+            )
+            if(touch){
+                return true;
+            }
+        }
+    }
+
+    return false;
+}


### PR DESCRIPTION
Car stops on impact on borders. 

Only works for current car speed. If car traveled faster, collision detection may not work in time.

Also, car visually touches border, but in slight instances, will not appear "damaged". Due to the fact, this code checks segments, or lines with imperceptible thickness whereas our borders have been padded for thickness and visibility. A fix to reduce thickness of borders to become infinitesimally smaller, but not necessary for these purposes.